### PR TITLE
fix: implement proposal-specific voting period restrictions

### DIFF
--- a/src/pages/proposal/create/EssentialForm.tsx
+++ b/src/pages/proposal/create/EssentialForm.tsx
@@ -24,7 +24,6 @@ import FormSection from './FormSection';
 import CaminoDatePicker from '@/components/DatePicker';
 import { usePendingMultisigAddProposalTxs } from '@/hooks/useMultisig';
 import useWallet from '@/hooks/useWallet';
-
 export const essentialSchema = (isAdminProposal: boolean) =>
   z.object({
     startDate: z
@@ -42,7 +41,6 @@ export const essentialSchema = (isAdminProposal: boolean) =>
       return url === '' ? undefined : url;
     }, z.string().url().optional()),
   });
-
 interface EssentialFormProps {
   proposalType: number | string;
   children?: ReactNode;
@@ -50,7 +48,7 @@ interface EssentialFormProps {
     schema: z.ZodRawShape;
     refine?: (fields: { [x: string]: any }) => void;
     error?: { path: string[]; message: string };
-    endDateRestriction?: { minDays: number; maxDays: number };
+    endDateRestriction?: { minDays: number; maxDays: number; fixed: any };
   };
   onCancel?: () => void;
 }
@@ -67,21 +65,65 @@ const EssentialForm = ({
       proposalIds.indexOf(ProposalTypes.AdminExcludeMember) === proposalType
     );
   }, [proposalType]);
+
+  const endDateRestriction = useMemo(() => {
+    const proposalIds = Object.values(ProposalTypes);
+    // Default restriction if no specific case matches
+    const defaultRestriction = {
+      minDays: formSchema.endDateRestriction?.minDays ?? 1,
+      maxDays: formSchema.endDateRestriction?.maxDays ?? 30,
+      fixed: formSchema.endDateRestriction?.fixed ?? false,
+    };
+
+    if (
+      proposalIds.indexOf(ProposalTypes.NewMember) === proposalType ||
+      proposalIds.indexOf(ProposalTypes.AdminNewMember) === proposalType
+    ) {
+      return {
+        minDays: 60,
+        maxDays: 60,
+        fixed: true,
+      };
+    } else if (
+      proposalIds.indexOf(ProposalTypes.ExcludeMember) === proposalType ||
+      proposalIds.indexOf(ProposalTypes.AdminExcludeMember) === proposalType
+    ) {
+      return {
+        minDays: 7,
+        maxDays: 30,
+        fixed: false,
+      };
+    } else if (proposalIds.indexOf(ProposalTypes.General) === proposalType) {
+      return {
+        minDays: 1,
+        maxDays: 30,
+        fixed: false,
+      };
+    }
+    return defaultRestriction;
+  }, [proposalType, formSchema.endDateRestriction]);
+
   const essentialRefinement = (fields: { [x: string]: any }) => {
     if (isAdminProposal) return true;
     const diffDays = fields.endDate
       .endOf('day')
       .diff(fields.startDate.startOf('day'), ['days']).days;
-    return diffDays > 1 && diffDays <= 30;
+    if (endDateRestriction.fixed) {
+      return diffDays === endDateRestriction.minDays;
+    }
+    return (
+      diffDays >= endDateRestriction.minDays &&
+      diffDays <= endDateRestriction.maxDays
+    );
   };
+
   const essentialRefinementError = {
     path: ['endDate'],
-    message: 'end date must after start date and maximum in 30 days',
+    message: endDateRestriction.fixed
+      ? `end date must be exactly ${endDateRestriction.minDays} days after start date`
+      : `end date must be between ${endDateRestriction.minDays} and ${endDateRestriction.maxDays} days after start date`,
   };
-  const endDateRestriction = formSchema.endDateRestriction ?? {
-    minDays: 1,
-    maxDays: 30,
-  };
+
   const schema = essentialSchema(isAdminProposal)
     .extend(formSchema.schema)
     .refine(
@@ -91,15 +133,36 @@ const EssentialForm = ({
   type CreateProposalSchema = z.infer<typeof schema>;
   const methods = useForm<CreateProposalSchema>({
     resolver: zodResolver(schema),
+    mode: 'onChange',
   });
-  const { handleSubmit, control, reset, formState, watch } = methods;
+
+  const { handleSubmit, control, formState, watch, setValue } = methods;
   const watchStartDate = watch('startDate', DateTime.now());
   const watchEndDate = watch('endDate');
+
+  // Effect to handle start date changes
   useEffect(() => {
-    reset({
-      startDate: DateTime.now(),
-    });
-  }, [isAdminProposal]);
+    if (watchStartDate) {
+      const newEndDate = watchStartDate.plus({
+        days: endDateRestriction.minDays,
+      });
+      if (endDateRestriction.fixed || !watchEndDate) {
+        setValue('endDate', newEndDate, { shouldValidate: true });
+      }
+    }
+  }, [watchStartDate, endDateRestriction.fixed, endDateRestriction.minDays]);
+
+  // Effect to initialize dates
+  useEffect(() => {
+    const now = DateTime.now();
+    setValue('startDate', now, { shouldValidate: true });
+    if (!isAdminProposal) {
+      setValue('endDate', now.plus({ days: endDateRestriction.minDays }), {
+        shouldValidate: true,
+      });
+    }
+  }, [isAdminProposal, proposalType]);
+
   const navigate = useNavigate();
   const toast = useToast();
   const activeNetwork = useNetworkStore(state => state.activeNetwork);
@@ -107,7 +170,6 @@ const EssentialForm = ({
   const { multisigWallet } = useWallet();
   const addProposal = useAddProposal(proposalType, {
     onSuccess: data => {
-      reset({});
       if (multisigWallet) {
         refetch();
         navigate('/dac/creating');
@@ -143,12 +205,7 @@ const EssentialForm = ({
 
   const diff = useMemo(() => {
     if (watchStartDate && watchEndDate) {
-      const diff = watchStartDate.diff(watchEndDate, [
-        'days',
-        'hours',
-        'minutes',
-      ]);
-      return diff;
+      return watchEndDate.diff(watchStartDate, ['days', 'hours', 'minutes']);
     }
     return null;
   }, [watchStartDate, watchEndDate]);
@@ -249,6 +306,7 @@ const EssentialForm = ({
                             <CaminoDatePicker
                               {...field}
                               disablePast
+                              disabled={endDateRestriction.fixed}
                               onChange={value => field.onChange(value)}
                               minDate={watchStartDate.plus({
                                 days: endDateRestriction.minDays,
@@ -283,7 +341,7 @@ const EssentialForm = ({
             variant="outlined"
             color="inherit"
             onClick={() => {
-              reset();
+              methods.reset();
               onCancel && onCancel();
             }}
           >
@@ -307,4 +365,5 @@ const EssentialForm = ({
     </FormProvider>
   );
 };
+
 export default React.memo(EssentialForm);

--- a/src/pages/proposal/create/ExcludeMemberForm.tsx
+++ b/src/pages/proposal/create/ExcludeMemberForm.tsx
@@ -47,13 +47,13 @@ export const excludeMemberFormSchema = (platformVMAPI?: PlatformVMAPI) => ({
     const diffDays = fields.endDate
       .endOf('day')
       .diff(fields.startDate.startOf('day'), ['days']).days;
-    return true;
+    return diffDays >= 7 && diffDays <= 30;
   },
   error: {
     path: ['endDate'],
-    message: 'end date should be 60 days after start date',
+    message: 'end date must be between 7 and 30 days after start date',
   },
-  endDateRestriction: { minDays: 7, maxDays: 30 },
+  endDateRestriction: { minDays: 7, maxDays: 30, fixed: false },
 });
 const ExcludeMemberForm = () => {
   const { control } = useFormContext();

--- a/src/pages/proposal/create/GeneralProposalForm.tsx
+++ b/src/pages/proposal/create/GeneralProposalForm.tsx
@@ -53,6 +53,17 @@ export const generalFormSchema = {
       .min(1, 'Proposal subject is required')
       .max(256, 'Proposal subject cannot exceed 256 characters'),
   },
+  refine: (fields: { [x: string]: any }) => {
+    const diffDays = fields.endDate
+      .startOf('day')
+      .diff(fields.startDate.startOf('day'), ['days']).days;
+    return diffDays >= 1 && diffDays <= 30;
+  },
+  error: {
+    path: ['endDate'],
+    message: 'end date must be between 1 and 30 days after start date',
+  },
+  endDateRestriction: { minDays: 1, maxDays: 30, fixed: false },
 };
 const schema = z.object(generalFormSchema.schema);
 type GeneralFormSchema = z.infer<typeof schema>;

--- a/src/pages/proposal/create/NewMemberForm.tsx
+++ b/src/pages/proposal/create/NewMemberForm.tsx
@@ -65,8 +65,9 @@ export const newMemberFormSchema = (platformVMAPI?: PlatformVMAPI) => ({
     path: ['endDate'],
     message: 'end date should be 60 days after start date',
   },
-  endDateRestriction: { minDays: 60, maxDays: 60 },
+  endDateRestriction: { minDays: 60, maxDays: 60, fixed: true },
 });
+
 const NewMemberForm = () => {
   const { control } = useFormContext();
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,10 +1986,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@c4tplatform/caminojs@^1.2.0-rc1":
-  version "1.2.0-rc1"
-  resolved "https://registry.yarnpkg.com/@c4tplatform/caminojs/-/caminojs-1.2.0-rc1.tgz#24f41054cdc7972944b714d7de0f21e078bb3f7e"
-  integrity sha512-wQDFr4vvnjwFGR8xVBQoYe2W+RbEt8bm7eE4h7cxftycDCKqb9t4kf8ewfH58aNhrAvmK8ZgXmIt6y5UJPDpKQ==
+"@c4tplatform/caminojs@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@c4tplatform/caminojs/-/caminojs-1.3.0.tgz#7002473e1c53596514dcde7558fd7a936f0c99e4"
+  integrity sha512-PVfYw74n24PZdsKgjwErzpTN9ijMoG0qyK3AoTHOx1bqtOlJzVN0jjOvVMVl/cfmMuqRCk+zgGDcLRBfYdBu3w==
   dependencies:
     assert "2.0.0"
     axios "^0.26.1"


### PR DESCRIPTION
- Implemented specific voting period restrictions for different proposal types:
  - New Member proposals: Fixed 60-day period
  - Exclude Member proposals: Flexible 7-30 day range
  - General proposals: Flexible 1-30 day range
- Added automatic end date calculation for fixed duration proposals
- Disabled end date picker UI for fixed duration proposals
- Improved date validation with proposal-specific error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button text styling with ellipsis and text overflow handling
	- Added transaction cancellation confirmation for pending multisig transactions
	- Improved proposal date validation and restrictions across different proposal types
	- Introduced new `VotingSection` component for more structured voting display

- **Bug Fixes**
	- Updated memo and title decoding for various proposal views
	- Refined validation logic for proposal end dates

- **Refactor**
	- Optimized performance with memoized callbacks and components
	- Improved type safety for React components
	- Simplified rendering logic in proposal-related components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->